### PR TITLE
Support react-router-dom 5.0.1+

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "mocha": "^3.4.2",
     "react": "16.x",
     "react-dom": "16.x",
-    "react-router-dom": "^4.1.1",
+    "react-router-dom": "^4.1.1 || ^5.0.1",
     "rimraf": "^2.6.1",
     "watch": "^1.0.2"
   }


### PR DESCRIPTION
As per this [release post](https://reacttraining.com/blog/react-router-v5/) v5 is backwards compatible with v4 (and should actually have been a minor version bump).